### PR TITLE
Add unit declarator to module declarations

### DIFF
--- a/lib/JSON/Pretty.pm
+++ b/lib/JSON/Pretty.pm
@@ -13,7 +13,7 @@
 # 
 # =end Pod
 
-module JSON::Pretty;
+unit module JSON::Pretty;
 
 proto to-json($, :$indent = 0, :$first = 0) is export {*}
 


### PR DESCRIPTION
As of Rakudo 2015.05, the `unit` declarator is required before using
`module`, `class` or `grammar` declarations (unless it uses a block).  Code
still using the old blockless semicolon form will throw a warning. This
commit stops the warning from appearing in the new Rakudo.