### PR TITLE
Fix removed @*INC

### DIFF
--- a/t/04-roundtrip.t
+++ b/t/04-roundtrip.t
@@ -1,5 +1,5 @@
 use Test;
-BEGIN { @*INC.push: 'lib' };
+use lib 'lib';
 use JSON::Pretty;
 
 my @s =


### PR DESCRIPTION
@*INC is no longer available. `use lib` is the new way.